### PR TITLE
Remove license from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,4 @@ python src/main.py
 
 See [Development Guidelines](docs/development.md) for setup instructions and contribution workflow.
 
-## 📄 License
 
-MIT License - see [LICENSE](LICENSE) for details.


### PR DESCRIPTION
Remove the license section from `README.md` as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-eeb490d4-cbb0-4fa8-8f5a-de51e1955522">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eeb490d4-cbb0-4fa8-8f5a-de51e1955522">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

